### PR TITLE
Add BBS+ signature suite and proof definitions

### DIFF
--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -82,10 +82,88 @@
         "@id": "https://w3id.org/security#Bls12381G2Key2020"
       },
       "BbsBlsSignature2020": {
-        "@id": "https://w3id.org/security#BbsBlsSignature2020"
+        "@id": "https://w3id.org/security#BbsBlsSignature2020",
+        "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "challenge": "https://w3id.org/security#challenge",
+            "created": {
+              "@id": "http://purl.org/dc/terms/created",
+              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            },
+            "domain": "https://w3id.org/security#domain",
+            "nonce": "https://w3id.org/security#nonce",
+            "proofPurpose": {
+              "@id": "https://w3id.org/security#proofPurpose",
+              "@type": "@vocab",
+              "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "sec": "https://w3id.org/security#",
+                "assertionMethod": {
+                  "@id": "https://w3id.org/security#assertionMethod",
+                  "@type": "@id",
+                  "@container": "@set"
+                },
+                "authentication": {
+                  "@id": "https://w3id.org/security#authenticationMethod",
+                  "@type": "@id",
+                  "@container": "@set"
+                }
+              }
+            },
+            "proofValue": "https://w3id.org/security#proofValue",
+            "verificationMethod": {
+              "@id": "https://w3id.org/security#verificationMethod",
+              "@type": "@id"
+            }
+        }
       },
       "BbsBlsSignatureProof2020": {
-        "@id": "https://w3id.org/security#BbsBlsSignatureProof2020"
+        "@id": "https://w3id.org/security#BbsBlsSignatureProof2020",
+        "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "challenge": "https://w3id.org/security#challenge",
+            "created": {
+              "@id": "http://purl.org/dc/terms/created",
+              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            },
+            "domain": "https://w3id.org/security#domain",
+            "nonce": "https://w3id.org/security#nonce",
+            "proofPurpose": {
+              "@id": "https://w3id.org/security#proofPurpose",
+              "@type": "@vocab",
+              "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "sec": "https://w3id.org/security#",
+                "assertionMethod": {
+                  "@id": "https://w3id.org/security#assertionMethod",
+                  "@type": "@id",
+                  "@container": "@set"
+                },
+                "authentication": {
+                  "@id": "https://w3id.org/security#authenticationMethod",
+                  "@type": "@id",
+                  "@container": "@set"
+                }
+              }
+            },
+            "proofValue": "https://w3id.org/security#proofValue",
+            "verificationMethod": {
+              "@id": "https://w3id.org/security#verificationMethod",
+              "@type": "@id"
+            }
+        }
       }
     }
   ]


### PR DESCRIPTION
PR dependent on #56 being merged ahead, adds complete definitions for `BbsBlsSignature2020` and `BbsBlsSignatureProof2020` if reviewing prior to merging of #56 see https://github.com/w3c-ccg/security-vocab/pull/58/commits/a59ee90e9ba0d44610d443a3cd716e1f750326e6