### PR TITLE
Fix use of public and private keys in examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,8 +993,8 @@ is described in the <a href="https://w3id.org/commerce">Commerce Vocabulary</a>.
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "privateKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+  "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
 </pre>
       </section>
@@ -1364,7 +1364,7 @@ that expires on January 3rd 2014:
   "created": "2012-01-03T14:34:57+0000",
   "expires": "2014-01-03T14:34:57+0000",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>
@@ -1531,7 +1531,7 @@ signed by a software agent of the owner:
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>
@@ -1580,7 +1580,7 @@ that has been abbreviated for the sake of the readability of the example.
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "privateKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
+  "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
 }
         </pre>
       </section>
@@ -1607,7 +1607,7 @@ that has been abbreviated for the sake of the readability of the example.
             "@id": "https://payswarm.example.com/i/bob/keys/1",
             "@type": "Key",
             "owner": "https://payswarm.example.com/i/bob",
-            "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+            "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
           }
                   </pre>
       </section>
@@ -1635,7 +1635,7 @@ to the identity <code>https://payswarm.example.com/i/bob</code>.
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "@type": "Key",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n"
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>
@@ -1978,7 +1978,7 @@ data that has been abbreviated for the sake of the readability of the example.
   "@context": "https://w3id.org/security/v1",
   "@id": "https://payswarm.example.com/i/bob/keys/1",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBG0BA...OClDQAB\n-----END PUBLIC KEY-----\n"
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>
@@ -2066,7 +2066,7 @@ revoked on May 5th 2012:
   "created": "2012-01-03T14:34:57+0000",
   "revoked": "2012-05-01T18:11:19+0000",
   "owner": "https://payswarm.example.com/i/bob",
-  "publicKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIBG0BA...OClDQAB\n-----END PRIVATE KEY-----\n",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMII8YbF3s8q3c...j8Fk88FsRa3K\n-----END PUBLIC KEY-----\n"
 }
         </pre>
       </section>


### PR DESCRIPTION
Some examples used `publicKeyPem` with a "BEGIN PRIVATE KEY" value, and vica-versa. This PR fixes them so that `publicKeyPem` has a "BEGIN PUBLIC KEY" value, and `privateKeyPem` has a "BEGIN PRIVATE KEY" value.

The public key is the one that contains value `MII8YbF3s8q3c`, and the private key is the one that contains `MIIBG0BA`.

I also updated trailing commas in some of the affected examples, to allow for stricter JSON parsing.

I am a member of the W3C CCG.