### PR TITLE
Add "sec" and "xsd" namespaces to RsaSignature2018

### DIFF
--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -339,6 +339,9 @@
         "@version": 1.1,
         "@protected": true,
 
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
         "challenge": "sec:challenge",
         "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
         "domain": "sec:domain",


### PR DESCRIPTION
Those are missing (and possibly in other places too).