### PR TITLE
feat: adds protected term from jsonld 1.1 to v3-unstable context

### DIFF
--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -233,21 +233,40 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose",
-          "@type": "@vocab",
-          "@context": {
-            "@version": 1.1,
-            "@protected": true,
-
-            "id": "@id",
-            "type": "@type",
-
-            "sec": "https://w3id.org/security#",
-
-            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
-            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
-          }
-        },
+            "@id": "https://w3id.org/security#proofPurpose",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "id": "@id",
+              "type": "@type",
+              "assertionMethod": {
+                "@id": "https://w3id.org/security#assertionMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "authentication": {
+                "@id": "https://w3id.org/security#authenticationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
+              }
+            }
+          },
         "proofValue": "sec:proofValue",
         "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
       }
@@ -311,21 +330,40 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose",
-          "@type": "@vocab",
-          "@context": {
-            "@version": 1.1,
-            "@protected": true,
-
-            "id": "@id",
-            "type": "@type",
-
-            "sec": "https://w3id.org/security#",
-
-            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
-            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
-          }
-        },
+            "@id": "https://w3id.org/security#proofPurpose",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "id": "@id",
+              "type": "@type",
+              "assertionMethod": {
+                "@id": "https://w3id.org/security#assertionMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "authentication": {
+                "@id": "https://w3id.org/security#authenticationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
+              }
+            }
+          },
         "proofValue": "sec:proofValue",
         "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
       }
@@ -349,21 +387,40 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose",
-          "@type": "@vocab",
-          "@context": {
-            "@version": 1.1,
-            "@protected": true,
-
-            "id": "@id",
-            "type": "@type",
-
-            "sec": "https://w3id.org/security#",
-
-            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
-            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
-          }
-        },
+            "@id": "https://w3id.org/security#proofPurpose",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "id": "@id",
+              "type": "@type",
+              "assertionMethod": {
+                "@id": "https://w3id.org/security#assertionMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "authentication": {
+                "@id": "https://w3id.org/security#authenticationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
+              }
+            }
+          },
         "proofValue": "sec:proofValue",
         "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
       }
@@ -392,21 +449,40 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose",
-          "@type": "@vocab",
-          "@context": {
-            "@version": 1.1,
-            "@protected": true,
-
-            "id": "@id",
-            "type": "@type",
-
-            "sec": "https://w3id.org/security#",
-
-            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
-            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
-          }
-        },
+            "@id": "https://w3id.org/security#proofPurpose",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "id": "@id",
+              "type": "@type",
+              "assertionMethod": {
+                "@id": "https://w3id.org/security#assertionMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "authentication": {
+                "@id": "https://w3id.org/security#authenticationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
+              }
+            }
+          },
         "proofValue": "sec:proofValue",
         "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
       }

--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -540,7 +540,6 @@
           }
         }
       },
-    "proofValue": "https://w3id.org/security#proofValue",
     "referenceId": "https://w3id.org/security#referenceId",
     "unwrappedKey": "https://w3id.org/security#unwrappedKey",
     "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"},

--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -1,11 +1,11 @@
 {
-  "@context": [
-    {
+  "@context": [{
       "@version": 1.1
     },
     {
       "id": "@id",
-      "type": "@type", 
+      "type": "@type",
+      "@protected": true,
       "JsonWebKey2020": {
         "@id": "https://w3id.org/security#JsonWebKey2020"
       },
@@ -50,6 +50,21 @@
                 "@id": "https://w3id.org/security#authenticationMethod",
                 "@type": "@id",
                 "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
               }
             }
           },
@@ -88,85 +103,113 @@
       "BbsBlsSignature2020": {
         "@id": "https://w3id.org/security#BbsBlsSignature2020",
         "@context": {
-            "@version": 1.1,
-            "@protected": true,
-            "id": "@id",
-            "type": "@type",
-            "challenge": "https://w3id.org/security#challenge",
-            "created": {
-              "@id": "http://purl.org/dc/terms/created",
-              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-            },
-            "domain": "https://w3id.org/security#domain",
-            "nonce": "https://w3id.org/security#nonce",
-            "proofPurpose": {
-              "@id": "https://w3id.org/security#proofPurpose",
-              "@type": "@vocab",
-              "@context": {
-                "@version": 1.1,
-                "@protected": true,
-                "id": "@id",
-                "type": "@type",
-                "sec": "https://w3id.org/security#",
-                "assertionMethod": {
-                  "@id": "https://w3id.org/security#assertionMethod",
-                  "@type": "@id",
-                  "@container": "@set"
-                },
-                "authentication": {
-                  "@id": "https://w3id.org/security#authenticationMethod",
-                  "@type": "@id",
-                  "@container": "@set"
-                }
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "challenge": "https://w3id.org/security#challenge",
+          "created": {
+            "@id": "http://purl.org/dc/terms/created",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+          },
+          "domain": "https://w3id.org/security#domain",
+          "nonce": "https://w3id.org/security#nonce",
+          "proofPurpose": {
+            "@id": "https://w3id.org/security#proofPurpose",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "id": "@id",
+              "type": "@type",
+              "assertionMethod": {
+                "@id": "https://w3id.org/security#assertionMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "authentication": {
+                "@id": "https://w3id.org/security#authenticationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
               }
-            },
-            "proofValue": "https://w3id.org/security#proofValue",
-            "verificationMethod": {
-              "@id": "https://w3id.org/security#verificationMethod",
-              "@type": "@id"
             }
+          },
+          "proofValue": "https://w3id.org/security#proofValue",
+          "verificationMethod": {
+            "@id": "https://w3id.org/security#verificationMethod",
+            "@type": "@id"
+          }
         }
       },
       "BbsBlsSignatureProof2020": {
         "@id": "https://w3id.org/security#BbsBlsSignatureProof2020",
         "@context": {
-            "@version": 1.1,
-            "@protected": true,
-            "id": "@id",
-            "type": "@type",
-            "challenge": "https://w3id.org/security#challenge",
-            "created": {
-              "@id": "http://purl.org/dc/terms/created",
-              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-            },
-            "domain": "https://w3id.org/security#domain",
-            "nonce": "https://w3id.org/security#nonce",
-            "proofPurpose": {
-              "@id": "https://w3id.org/security#proofPurpose",
-              "@type": "@vocab",
-              "@context": {
-                "@version": 1.1,
-                "@protected": true,
-                "id": "@id",
-                "type": "@type",
-                "sec": "https://w3id.org/security#",
-                "assertionMethod": {
-                  "@id": "https://w3id.org/security#assertionMethod",
-                  "@type": "@id",
-                  "@container": "@set"
-                },
-                "authentication": {
-                  "@id": "https://w3id.org/security#authenticationMethod",
-                  "@type": "@id",
-                  "@container": "@set"
-                }
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "challenge": "https://w3id.org/security#challenge",
+          "created": {
+            "@id": "http://purl.org/dc/terms/created",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+          },
+          "domain": "https://w3id.org/security#domain",
+          "nonce": "https://w3id.org/security#nonce",
+          "proofPurpose": {
+            "@id": "https://w3id.org/security#proofPurpose",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "id": "@id",
+              "type": "@type",
+              "assertionMethod": {
+                "@id": "https://w3id.org/security#assertionMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "authentication": {
+                "@id": "https://w3id.org/security#authenticationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityInvocation": {
+                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "capabilityDelegation": {
+                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                "@type": "@id",
+                "@container": "@set"
+              },
+              "keyAgreement": {
+                "@id": "https://w3id.org/security#keyAgreementMethod",
+                "@type": "@id",
+                "@container": "@set"
               }
-            },
-            "proofValue": "https://w3id.org/security#proofValue",
-            "verificationMethod": {
-              "@id": "https://w3id.org/security#verificationMethod",
-              "@type": "@id"
             }
+          },
+          "proofValue": "https://w3id.org/security#proofValue",
+          "verificationMethod": {
+            "@id": "https://w3id.org/security#verificationMethod",
+            "@type": "@id"
+          }
         }
       },
 
@@ -398,8 +441,42 @@
     "kmsModule": {"@id": "https://w3id.org/security#kmsModule"},
     "parentCapability": {"@id": "https://w3id.org/security#parentCapability", "@type": "@id"},
     "plaintext": "https://w3id.org/security#plaintext",
-    "proof": {"@id": "https://w3id.org/security#proof", "@type": "@id", "@container": "@graph"},
-    "proofPurpose": {"@id": "https://w3id.org/security#proofPurpose", "@type": "@vocab"},
+    "proof": {"@id": "https://w3id.org/security#proof","@type": "@id","@container": "@graph"},
+      "proofPurpose": {
+        "@id": "https://w3id.org/security#proofPurpose",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "assertionMethod": {
+            "@id": "https://w3id.org/security#assertionMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "authentication": {
+            "@id": "https://w3id.org/security#authenticationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "capabilityInvocation": {
+            "@id": "https://w3id.org/security#capabilityInvocationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "capabilityDelegation": {
+            "@id": "https://w3id.org/security#capabilityDelegationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "keyAgreement": {
+            "@id": "https://w3id.org/security#keyAgreementMethod",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
     "proofValue": "https://w3id.org/security#proofValue",
     "referenceId": "https://w3id.org/security#referenceId",
     "unwrappedKey": "https://w3id.org/security#unwrappedKey",

--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -1,7 +1,5 @@
 {
-  "@context": [{
-      "@version": 1.1
-    },
+  "@context": [
     {
       "id": "@id",
       "type": "@type",
@@ -18,7 +16,6 @@
       "Ed25519Signature2020": {
         "@id": "https://w3id.org/security#Ed25519Signature2020",
         "@context": {
-          "@version": 1.1,
           "@protected": true,
           "id": "@id",
           "type": "@type",
@@ -37,7 +34,6 @@
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
             "@context": {
-              "@version": 1.1,
               "@protected": true,
               "id": "@id",
               "type": "@type",
@@ -103,7 +99,6 @@
       "BbsBlsSignature2020": {
         "@id": "https://w3id.org/security#BbsBlsSignature2020",
         "@context": {
-          "@version": 1.1,
           "@protected": true,
           "id": "@id",
           "type": "@type",
@@ -118,7 +113,6 @@
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
             "@context": {
-              "@version": 1.1,
               "@protected": true,
               "id": "@id",
               "type": "@type",
@@ -159,7 +153,6 @@
       "BbsBlsSignatureProof2020": {
         "@id": "https://w3id.org/security#BbsBlsSignatureProof2020",
         "@context": {
-          "@version": 1.1,
           "@protected": true,
           "id": "@id",
           "type": "@type",
@@ -174,7 +167,6 @@
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
             "@context": {
-              "@version": 1.1,
               "@protected": true,
               "id": "@id",
               "type": "@type",
@@ -217,7 +209,6 @@
     "Ed25519Signature2018": {
       "@id": "https://w3id.org/security#Ed25519Signature2018",
       "@context": {
-        "@version": 1.1,
         "@protected": true,
 
         "id": "@id",
@@ -314,7 +305,6 @@
     "EcdsaSecp256k1Signature2019": {
       "@id": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
       "@context": {
-        "@version": 1.1,
         "@protected": true,
 
         "id": "@id",
@@ -371,7 +361,6 @@
     "EcdsaSecp256r1Signature2019": {
       "@id": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
       "@context": {
-        "@version": 1.1,
         "@protected": true,
 
         "id": "@id",
@@ -436,7 +425,6 @@
     "RsaSignature2018": {
       "@id": "https://w3id.org/security#RsaSignature2018",
       "@context": {
-        "@version": 1.1,
         "@protected": true,
 
         "sec": "https://w3id.org/security#",
@@ -522,7 +510,6 @@
         "@id": "https://w3id.org/security#proofPurpose",
         "@type": "@vocab",
         "@context": {
-          "@version": 1.1,
           "@protected": true,
           "id": "@id",
           "type": "@type",


### PR DESCRIPTION
This PR implements options 2 from [this comment](https://github.com/w3c-ccg/security-vocab/issues/75#issuecomment-729836345) so we can close #75

It should be noted that v3-context at the moment is incompatible with the VC context because of the bug that @peacekeeper discovered. I've started work to define a 2020 VC context [here](https://github.com/mattrglobal/jsonld-signatures-bbs/blob/46f3b8ae0aa49ffce789411d9132d6768cb178ff/__tests__/__fixtures__/contexts/credential_vocab.json) as well which would remove the LDS suites from the VC context.

This is a working example that removes the LDS suites from the VC context and puts it under the 2020 URL. However there's still changes that need to be made to it to point the URLs at the VC spec definition of the properties and to update vc-js (take a look at the [whole PR](https://github.com/mattrglobal/jsonld-signatures-bbs/pull/89) in jsonld-signatures-bbs to see the direction I'm looking to go) so that it checks for either the 2018 VC context or 2020 VC context in the first position of the context array.