### PR TITLE
Additional cleanup of the V3 security context

### DIFF
--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -214,15 +214,12 @@
         "id": "@id",
         "type": "@type",
 
-        "sec": "https://w3id.org/security#",
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
-
-        "challenge": "sec:challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
-        "domain": "sec:domain",
-        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
-        "jws": "sec:jws",
-        "nonce": "sec:nonce",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "domain": "https://w3id.org/security#domain",
+        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
@@ -258,8 +255,8 @@
               }
             }
           },
-        "proofValue": "sec:proofValue",
-        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
       }
     },
     "EncryptedMessage": "https://w3id.org/security#EncryptedMessage",
@@ -310,15 +307,12 @@
         "id": "@id",
         "type": "@type",
 
-        "sec": "https://w3id.org/security#",
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
-
-        "challenge": "sec:challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
-        "domain": "sec:domain",
-        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
-        "jws": "sec:jws",
-        "nonce": "sec:nonce",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "domain": "https://w3id.org/security#domain",
+        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
@@ -354,8 +348,8 @@
               }
             }
           },
-        "proofValue": "sec:proofValue",
-        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
       }
     },
     "EcdsaSecp256r1Signature2019": {
@@ -366,15 +360,12 @@
         "id": "@id",
         "type": "@type",
 
-        "sec": "https://w3id.org/security#",
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
-
-        "challenge": "sec:challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
-        "domain": "sec:domain",
-        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
-        "jws": "sec:jws",
-        "nonce": "sec:nonce",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "domain": "https://w3id.org/security#domain",
+        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
@@ -410,8 +401,8 @@
               }
             }
           },
-        "proofValue": "sec:proofValue",
-        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
       }
     },
     "EcdsaSecp256k1VerificationKey2019": "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019",
@@ -427,15 +418,12 @@
       "@context": {
         "@protected": true,
 
-        "sec": "https://w3id.org/security#",
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
-
-        "challenge": "sec:challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
-        "domain": "sec:domain",
-        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
-        "jws": "sec:jws",
-        "nonce": "sec:nonce",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "domain": "https://w3id.org/security#domain",
+        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
             "@id": "https://w3id.org/security#proofPurpose",
             "@type": "@vocab",
@@ -471,8 +459,8 @@
               }
             }
           },
-        "proofValue": "sec:proofValue",
-        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
       }
     },
     "RsaVerificationKey2018": "https://w3id.org/security#RsaVerificationKey2018",
@@ -496,8 +484,8 @@
     "ciphertext": "https://w3id.org/security#ciphertext",
     "controller": {"@id": "https://w3id.org/security#controller", "@type": "@id"},
     "delegator": {"@id": "https://w3id.org/security#delegator", "@type": "@id"},
-    "equihashParameterK": {"@id": "https://w3id.org/security#equihashParameterK", "@type": "xsd:integer"},
-    "equihashParameterN": {"@id": "https://w3id.org/security#equihashParameterN", "@type": "xsd:integer"},
+    "equihashParameterK": {"@id": "https://w3id.org/security#equihashParameterK", "@type": "http://www.w3.org/2001/XMLSchema#:integer"},
+    "equihashParameterN": {"@id": "https://w3id.org/security#equihashParameterN", "@type": "http://www.w3.org/2001/XMLSchema#:integer"},
     "invocationTarget": {"@id": "https://w3id.org/security#invocationTarget", "@type": "@id"},
     "invoker": {"@id": "https://w3id.org/security#invoker", "@type": "@id"},
     "jws": "https://w3id.org/security#jws",

--- a/contexts/security-v3-unstable.jsonld
+++ b/contexts/security-v3-unstable.jsonld
@@ -1,209 +1,208 @@
 {
-  "@context": [
-    {
-      "id": "@id",
-      "type": "@type",
-      "@protected": true,
-      "JsonWebKey2020": {
-        "@id": "https://w3id.org/security#JsonWebKey2020"
-      },
-      "JsonWebSignature2020": {
-        "@id": "https://w3id.org/security#JsonWebSignature2020"
-      },
-      "Ed25519VerificationKey2020": {
-        "@id": "https://w3id.org/security#Ed25519VerificationKey2020"
-      },
-      "Ed25519Signature2020": {
-        "@id": "https://w3id.org/security#Ed25519Signature2020",
-        "@context": {
-          "@protected": true,
-          "id": "@id",
-          "type": "@type",
-          "challenge": "https://w3id.org/security#challenge",
-          "created": {
-            "@id": "http://purl.org/dc/terms/created",
-            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-          },
-          "domain": "https://w3id.org/security#domain",
-          "expires": {
-            "@id": "https://w3id.org/security#expiration",
-            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-          },
-          "nonce": "https://w3id.org/security#nonce",
-          "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+  "@context": [{
+    "id": "@id",
+    "type": "@type",
+    "@protected": true,
+    "JsonWebKey2020": {
+      "@id": "https://w3id.org/security#JsonWebKey2020"
+    },
+    "JsonWebSignature2020": {
+      "@id": "https://w3id.org/security#JsonWebSignature2020"
+    },
+    "Ed25519VerificationKey2020": {
+      "@id": "https://w3id.org/security#Ed25519VerificationKey2020"
+    },
+    "Ed25519Signature2020": {
+      "@id": "https://w3id.org/security#Ed25519Signature2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
-          "proofValue": {
-            "@id": "https://w3id.org/security#proofValue",
-            "@type": "https://w3id.org/security#multibase"
-          },
-          "verificationMethod": {
-            "@id": "https://w3id.org/security#verificationMethod",
-            "@type": "@id"
           }
+        },
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
         }
-      },
-      "publicKeyJwk": {
-        "@id": "https://w3id.org/security#publicKeyJwk",
-        "@type": "@json"
-      },
-      "ethereumAddress": {
-        "@id": "https://w3id.org/security#ethereumAddress"
-      },
-      "publicKeyHex": {
-        "@id": "https://w3id.org/security#publicKeyHex"
-      },
-      "blockchainAccountId": {
-        "@id": "https://w3id.org/security#blockchainAccountId"
-      },
-      "MerkleProof2019": {
-        "@id": "https://w3id.org/security#MerkleProof2019"
-      },
-      "Bls12381G1Key2020": {
-        "@id": "https://w3id.org/security#Bls12381G1Key2020"
-      },
-      "Bls12381G2Key2020": {
-        "@id": "https://w3id.org/security#Bls12381G2Key2020"
-      },
-      "BbsBlsSignature2020": {
-        "@id": "https://w3id.org/security#BbsBlsSignature2020",
-        "@context": {
-          "@protected": true,
-          "id": "@id",
-          "type": "@type",
-          "challenge": "https://w3id.org/security#challenge",
-          "created": {
-            "@id": "http://purl.org/dc/terms/created",
-            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-          },
-          "domain": "https://w3id.org/security#domain",
-          "nonce": "https://w3id.org/security#nonce",
-          "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+      }
+    },
+    "publicKeyJwk": {
+      "@id": "https://w3id.org/security#publicKeyJwk",
+      "@type": "@json"
+    },
+    "ethereumAddress": {
+      "@id": "https://w3id.org/security#ethereumAddress"
+    },
+    "publicKeyHex": {
+      "@id": "https://w3id.org/security#publicKeyHex"
+    },
+    "blockchainAccountId": {
+      "@id": "https://w3id.org/security#blockchainAccountId"
+    },
+    "MerkleProof2019": {
+      "@id": "https://w3id.org/security#MerkleProof2019"
+    },
+    "Bls12381G1Key2020": {
+      "@id": "https://w3id.org/security#Bls12381G1Key2020"
+    },
+    "Bls12381G2Key2020": {
+      "@id": "https://w3id.org/security#Bls12381G2Key2020"
+    },
+    "BbsBlsSignature2020": {
+      "@id": "https://w3id.org/security#BbsBlsSignature2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
-          "proofValue": "https://w3id.org/security#proofValue",
-          "verificationMethod": {
-            "@id": "https://w3id.org/security#verificationMethod",
-            "@type": "@id"
           }
+        },
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
         }
-      },
-      "BbsBlsSignatureProof2020": {
-        "@id": "https://w3id.org/security#BbsBlsSignatureProof2020",
-        "@context": {
-          "@protected": true,
-          "id": "@id",
-          "type": "@type",
-          "challenge": "https://w3id.org/security#challenge",
-          "created": {
-            "@id": "http://purl.org/dc/terms/created",
-            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-          },
-          "domain": "https://w3id.org/security#domain",
-          "nonce": "https://w3id.org/security#nonce",
-          "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+      }
+    },
+    "BbsBlsSignatureProof2020": {
+      "@id": "https://w3id.org/security#BbsBlsSignatureProof2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
-          "proofValue": "https://w3id.org/security#proofValue",
-          "verificationMethod": {
-            "@id": "https://w3id.org/security#verificationMethod",
-            "@type": "@id"
           }
+        },
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
         }
-      },
+      }
+    },
 
     "EcdsaKoblitzSignature2016": "https://w3id.org/security#EcdsaKoblitzSignature2016",
     "Ed25519Signature2018": {
@@ -215,48 +214,57 @@
         "type": "@type",
 
         "challenge": "https://w3id.org/security#challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "domain": "https://w3id.org/security#domain",
-        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "jws": "https://w3id.org/security#jws",
         "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@version": 1.1,
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
+          }
+        },
         "proofValue": "https://w3id.org/security#proofValue",
-        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
       }
     },
     "EncryptedMessage": "https://w3id.org/security#EncryptedMessage",
@@ -269,28 +277,43 @@
     "cipherAlgorithm": "https://w3id.org/security#cipherAlgorithm",
     "cipherData": "https://w3id.org/security#cipherData",
     "cipherKey": "https://w3id.org/security#cipherKey",
-    "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
-    "creator": {"@id": "http://purl.org/dc/terms/creator", "@type": "@id"},
+    "created": {
+      "@id": "http://purl.org/dc/terms/created",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "creator": {
+      "@id": "http://purl.org/dc/terms/creator",
+      "@type": "@id"
+    },
     "digestAlgorithm": "https://w3id.org/security#digestAlgorithm",
     "digestValue": "https://w3id.org/security#digestValue",
     "domain": "https://w3id.org/security#domain",
     "encryptionKey": "https://w3id.org/security#encryptionKey",
-    "expiration": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
-    "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+    "expiration": {
+      "@id": "https://w3id.org/security#expiration",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "expires": {
+      "@id": "https://w3id.org/security#expiration",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
     "initializationVector": "https://w3id.org/security#initializationVector",
     "iterationCount": "https://w3id.org/security#iterationCount",
     "nonce": "https://w3id.org/security#nonce",
     "normalizationAlgorithm": "https://w3id.org/security#normalizationAlgorithm",
     "owner": "https://w3id.org/security#owner",
     "password": "https://w3id.org/security#password",
-    "privateKey":"https://w3id.org/security#privateKey",
+    "privateKey": "https://w3id.org/security#privateKey",
     "privateKeyPem": "https://w3id.org/security#privateKeyPem",
     "publicKey": "https://w3id.org/security#publicKey",
     "publicKeyBase58": "https://w3id.org/security#publicKeyBase58",
     "publicKeyPem": "https://w3id.org/security#publicKeyPem",
     "publicKeyWif": "https://w3id.org/security#publicKeyWif",
     "publicKeyService": "https://w3id.org/security#publicKeyService",
-    "revoked": {"@id": "https://w3id.org/security#revoked", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+    "revoked": {
+      "@id": "https://w3id.org/security#revoked",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
     "salt": "https://w3id.org/security#salt",
     "signature": "https://w3id.org/security#signature",
     "signatureAlgorithm": "https://w3id.org/security#signingAlgorithm",
@@ -308,48 +331,57 @@
         "type": "@type",
 
         "challenge": "https://w3id.org/security#challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "domain": "https://w3id.org/security#domain",
-        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "jws": "https://w3id.org/security#jws",
         "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@version": 1.1,
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
+          }
+        },
         "proofValue": "https://w3id.org/security#proofValue",
-        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
       }
     },
     "EcdsaSecp256r1Signature2019": {
@@ -361,48 +393,57 @@
         "type": "@type",
 
         "challenge": "https://w3id.org/security#challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "domain": "https://w3id.org/security#domain",
-        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "jws": "https://w3id.org/security#jws",
         "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@version": 1.1,
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
+          }
+        },
         "proofValue": "https://w3id.org/security#proofValue",
-        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
       }
     },
     "EcdsaSecp256k1VerificationKey2019": "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019",
@@ -419,48 +460,57 @@
         "@protected": true,
 
         "challenge": "https://w3id.org/security#challenge",
-        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "domain": "https://w3id.org/security#domain",
-        "expires": {"@id": "https://w3id.org/security#expiration", "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"},
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#:dateTime"
+        },
         "jws": "https://w3id.org/security#jws",
         "nonce": "https://w3id.org/security#nonce",
         "proofPurpose": {
-            "@id": "https://w3id.org/security#proofPurpose",
-            "@type": "@vocab",
-            "@context": {
-              "@version": 1.1,
-              "@protected": true,
-              "id": "@id",
-              "type": "@type",
-              "assertionMethod": {
-                "@id": "https://w3id.org/security#assertionMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "authentication": {
-                "@id": "https://w3id.org/security#authenticationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityInvocation": {
-                "@id": "https://w3id.org/security#capabilityInvocationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "capabilityDelegation": {
-                "@id": "https://w3id.org/security#capabilityDelegationMethod",
-                "@type": "@id",
-                "@container": "@set"
-              },
-              "keyAgreement": {
-                "@id": "https://w3id.org/security#keyAgreementMethod",
-                "@type": "@id",
-                "@container": "@set"
-              }
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
             }
-          },
+          }
+        },
         "proofValue": "https://w3id.org/security#proofValue",
-        "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"}
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
       }
     },
     "RsaVerificationKey2018": "https://w3id.org/security#RsaVerificationKey2018",
@@ -472,67 +522,127 @@
     "X25519KeyAgreementKey2019": "https://w3id.org/security#X25519KeyAgreementKey2019",
 
     "allowedAction": "https://w3id.org/security#allowedAction",
-    "assertionMethod": {"@id": "https://w3id.org/security#assertionMethod", "@type": "@id", "@container": "@set"},
-    "authentication": {"@id": "https://w3id.org/security#authenticationMethod", "@type": "@id", "@container": "@set"},
-    "capability": {"@id": "https://w3id.org/security#capability", "@type": "@id"},
+    "assertionMethod": {
+      "@id": "https://w3id.org/security#assertionMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "authentication": {
+      "@id": "https://w3id.org/security#authenticationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capability": {
+      "@id": "https://w3id.org/security#capability",
+      "@type": "@id"
+    },
     "capabilityAction": "https://w3id.org/security#capabilityAction",
-    "capabilityChain": {"@id": "https://w3id.org/security#capabilityChain", "@type": "@id", "@container": "@list"},
-    "capabilityDelegation": {"@id": "https://w3id.org/security#capabilityDelegationMethod", "@type": "@id", "@container": "@set"},
-    "capabilityInvocation": {"@id": "https://w3id.org/security#capabilityInvocationMethod", "@type": "@id", "@container": "@set"},
-    "caveat": {"@id": "https://w3id.org/security#caveat", "@type": "@id", "@container": "@set"},
+    "capabilityChain": {
+      "@id": "https://w3id.org/security#capabilityChain",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "capabilityDelegation": {
+      "@id": "https://w3id.org/security#capabilityDelegationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityInvocation": {
+      "@id": "https://w3id.org/security#capabilityInvocationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "caveat": {
+      "@id": "https://w3id.org/security#caveat",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "challenge": "https://w3id.org/security#challenge",
     "ciphertext": "https://w3id.org/security#ciphertext",
-    "controller": {"@id": "https://w3id.org/security#controller", "@type": "@id"},
-    "delegator": {"@id": "https://w3id.org/security#delegator", "@type": "@id"},
-    "equihashParameterK": {"@id": "https://w3id.org/security#equihashParameterK", "@type": "http://www.w3.org/2001/XMLSchema#:integer"},
-    "equihashParameterN": {"@id": "https://w3id.org/security#equihashParameterN", "@type": "http://www.w3.org/2001/XMLSchema#:integer"},
-    "invocationTarget": {"@id": "https://w3id.org/security#invocationTarget", "@type": "@id"},
-    "invoker": {"@id": "https://w3id.org/security#invoker", "@type": "@id"},
+    "controller": {
+      "@id": "https://w3id.org/security#controller",
+      "@type": "@id"
+    },
+    "delegator": {
+      "@id": "https://w3id.org/security#delegator",
+      "@type": "@id"
+    },
+    "equihashParameterK": {
+      "@id": "https://w3id.org/security#equihashParameterK",
+      "@type": "http://www.w3.org/2001/XMLSchema#:integer"
+    },
+    "equihashParameterN": {
+      "@id": "https://w3id.org/security#equihashParameterN",
+      "@type": "http://www.w3.org/2001/XMLSchema#:integer"
+    },
+    "invocationTarget": {
+      "@id": "https://w3id.org/security#invocationTarget",
+      "@type": "@id"
+    },
+    "invoker": {
+      "@id": "https://w3id.org/security#invoker",
+      "@type": "@id"
+    },
     "jws": "https://w3id.org/security#jws",
-    "keyAgreement": {"@id": "https://w3id.org/security#keyAgreementMethod", "@type": "@id", "@container": "@set"},
-    "kmsModule": {"@id": "https://w3id.org/security#kmsModule"},
-    "parentCapability": {"@id": "https://w3id.org/security#parentCapability", "@type": "@id"},
+    "keyAgreement": {
+      "@id": "https://w3id.org/security#keyAgreementMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "kmsModule": {
+      "@id": "https://w3id.org/security#kmsModule"
+    },
+    "parentCapability": {
+      "@id": "https://w3id.org/security#parentCapability",
+      "@type": "@id"
+    },
     "plaintext": "https://w3id.org/security#plaintext",
-    "proof": {"@id": "https://w3id.org/security#proof","@type": "@id","@container": "@graph"},
-      "proofPurpose": {
-        "@id": "https://w3id.org/security#proofPurpose",
-        "@type": "@vocab",
-        "@context": {
-          "@protected": true,
-          "id": "@id",
-          "type": "@type",
-          "assertionMethod": {
-            "@id": "https://w3id.org/security#assertionMethod",
-            "@type": "@id",
-            "@container": "@set"
-          },
-          "authentication": {
-            "@id": "https://w3id.org/security#authenticationMethod",
-            "@type": "@id",
-            "@container": "@set"
-          },
-          "capabilityInvocation": {
-            "@id": "https://w3id.org/security#capabilityInvocationMethod",
-            "@type": "@id",
-            "@container": "@set"
-          },
-          "capabilityDelegation": {
-            "@id": "https://w3id.org/security#capabilityDelegationMethod",
-            "@type": "@id",
-            "@container": "@set"
-          },
-          "keyAgreement": {
-            "@id": "https://w3id.org/security#keyAgreementMethod",
-            "@type": "@id",
-            "@container": "@set"
-          }
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "proofPurpose": {
+      "@id": "https://w3id.org/security#proofPurpose",
+      "@type": "@vocab",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "assertionMethod": {
+          "@id": "https://w3id.org/security#assertionMethod",
+          "@type": "@id",
+          "@container": "@set"
+        },
+        "authentication": {
+          "@id": "https://w3id.org/security#authenticationMethod",
+          "@type": "@id",
+          "@container": "@set"
+        },
+        "capabilityInvocation": {
+          "@id": "https://w3id.org/security#capabilityInvocationMethod",
+          "@type": "@id",
+          "@container": "@set"
+        },
+        "capabilityDelegation": {
+          "@id": "https://w3id.org/security#capabilityDelegationMethod",
+          "@type": "@id",
+          "@container": "@set"
+        },
+        "keyAgreement": {
+          "@id": "https://w3id.org/security#keyAgreementMethod",
+          "@type": "@id",
+          "@container": "@set"
         }
-      },
+      }
+    },
     "referenceId": "https://w3id.org/security#referenceId",
     "unwrappedKey": "https://w3id.org/security#unwrappedKey",
-    "verificationMethod": {"@id": "https://w3id.org/security#verificationMethod", "@type": "@id"},
+    "verificationMethod": {
+      "@id": "https://w3id.org/security#verificationMethod",
+      "@type": "@id"
+    },
     "verifyData": "https://w3id.org/security#verifyData",
     "wrappedKey": "https://w3id.org/security#wrappedKey"
-    }
-  ]
+  }]
 }


### PR DESCRIPTION
This makes 2 changes:

1. removes all short form identifiers that were left over from us trying to align v3 security vocab with the VC v1 context.
2. Linted the v3 context so that it's more readable

Note it's been built on PR #78 so once this is merged only the last two commits will be left over making it slightly easier to review per commit.