### PR TITLE
Add publicKeyMultibase definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2100,7 +2100,10 @@ A <code>publicKeyHex</code> property is used to specify the hex-encoded version 
         <h3>publicKeyMultibase</h3>
         <p>
 The public key multibase property is used to specify the multibase-encoded
-version of a public key.
+version of a public key. Each key type definition is expected to specify
+one or more required encoding bases. Specifying only a single encoding
+base per key type is preferable as it reduces the burden to reach broad
+interoperability.
                   </p>
                   <dl>
                     <dt>Status</dt>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,50 @@ companyURL: "https://mattr.global/"
           github: "https://github.com/w3c-ccg/security-vocab/",
 
           // extend the bibliography entries
-          //localBiblio: webpayments.localBiblio,
+          localBiblio: {
+            "ED25519-2020": {
+              title: "Ed25519 Signature 2020",
+              date: "November 2020",
+              href: "https://w3c-ccg.github.io/lds-ed25519-2020/",
+              authors: [
+                "Orie Steele"
+              ],
+              status: "Community Group Draft",
+              publisher: "W3C Credentials Community Group"
+            },
+            "LD-CRYPTOSUITE-REGISTRY": {
+              title: "The Linked Data Cryptosuite Registry",
+              date: "May 2021",
+              href: "https://w3c-ccg.github.io/ld-cryptosuite-registry/",
+              authors: [
+                "Manu Sporny",
+                "Orie Steele"
+              ],
+              status: "W3C Community Group Draft",
+              publisher: "W3C Credentials Community Group"
+            },
+            "MULTIBASE": {
+              title: "The Multibase Data Format",
+              date: "February 2021",
+              href: "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03",
+              authors: [
+                "Manu Sporny"
+              ],
+              status: "Internet-Draft",
+              publisher: "IETF"
+            },
+            "MULTICODEC": {
+              title: "The Multicodec Data Format",
+              date: "May 2021",
+              href: "https://github.com/multiformats/multicodec/blob/master/table.csv",
+              authors: [
+                "Steven Allen",
+                "David Dias"
+              ],
+              status: "Draft",
+              publisher: "Protocol Labs"
+            }
+          },
 
           // name of the WG
           wg:       "Credentials Community Group",
@@ -2099,12 +2142,28 @@ A <code>publicKeyHex</code> property is used to specify the hex-encoded version 
       typeof="rdf:Property">
         <h3>publicKeyMultibase</h3>
         <p>
-The public key multibase property is used to specify the multibase-encoded
-version of a public key. Each key type definition is expected to specify
-one or more required encoding bases. Specifying only a single encoding
-base per key type is preferable as it reduces the burden to reach broad
+The public key multibase [[MULTIBASE]] property is used to specify the
+multibase-encoded version of a public key. The contents of the property
+are defined by specifications such as [[ED25519-2020]] and listed in the
+Linked Data Cryptosuite Registry [[LD-CRYPTOSUITE-REGISTRY]]. Most public key
+type definitions are expected to:
+        </p>
+
+        <ul>
+          <li>
+Specify only a single encoding base per public key type as it reduces
+implementation burden and increases the chances of reaching broad
 interoperability.
-                  </p>
+          </li>
+          <li>
+Specify a multicodec [[MULTICODEC]] header on the encoded public key to aid
+encoding and decoding applications in confirming that they are serializing and
+deserializing an expected public key type.
+          </li>
+          <li>
+Use compressed binary formats to ensure efficient key sizes.
+          </li>
+        </ul>
                   <dl>
                     <dt>Status</dt>
                     <dd property="vs:term_status">unstable</dd>

--- a/index.html
+++ b/index.html
@@ -2099,8 +2099,8 @@ A <code>publicKeyHex</code> property is used to specify the hex-encoded version 
       typeof="rdf:Property">
         <h3>publicKeyMultibase</h3>
         <p>
-An public key multibase property is used to specify the multibase-encoded
-version of the public key.
+The public key multibase property is used to specify the multibase-encoded
+version of a public key.
                   </p>
                   <dl>
                     <dt>Status</dt>

--- a/index.html
+++ b/index.html
@@ -1965,6 +1965,11 @@ to the identity <code>did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5
       <section id="publicKeyBase58" about="https://w3id.org/security#publicKeyBase58"
       typeof="rdf:Property">
         <h3>publicKeyBase58</h3>
+        <p class="note" title="The publicKeyBase58 property is deprecated.">
+The `publicKeyBase58` property is deprecated. New cryptography suite creators
+and developers are advised to use the `publicKeyMultibase` property for
+encoding public key parameters.
+        </p>
         <p>
           A public key Base58 property is used to specify the base58-encoded version of the
           public key.
@@ -2060,6 +2065,11 @@ data that has been abbreviated for the sake of the readability of the example.
       <section id="publicKeyHex" about="https://w3id.org/security#publicKeyHex"
       typeof="rdf:Property">
         <h3>publicKeyHex</h3>
+        <p class="note" title="The publicKeyHex property is deprecated.">
+The `publicKeyHex` property is deprecated. New cryptography suite creators
+and developers are advised to use the `publicKeyMultibase` property for encoding
+public key parameters.
+        </p>
         <p>
 A <code>publicKeyHex</code> property is used to specify the hex-encoded version of the public key, based on <a href="https://tools.ietf.org/html/rfc4648#section-8">section 8 of rfc4648</a>. Hex encoding is also known as Base16 encoding.
         </p>
@@ -2083,6 +2093,36 @@ A <code>publicKeyHex</code> property is used to specify the hex-encoded version 
     "publicKeyHex":"027560AF3387D375E3342A6968179EF3C6D04F5D33B2B611CF326D4708BADD7770"
 }
         </pre>
+      </section>
+
+      <section id="publicKeyMultibase" about="https://w3id.org/security#publicKeyMultibase"
+      typeof="rdf:Property">
+        <h3>publicKeyMultibase</h3>
+        <p>
+An public key multibase property is used to specify the multibase-encoded
+version of the public key.
+                  </p>
+                  <dl>
+                    <dt>Status</dt>
+                    <dd property="vs:term_status">unstable</dd>
+                    <dt>Domain</dt>
+                    <dd>Key</dd>
+                    <dt>Range</dt>
+                    <dd>xsd:string</dd>
+                  </dl>
+                  <p>
+          The following example demonstrates the expression of a public key
+          in multibase format.
+                  </p>
+                  <pre class="example prettyprint language-jsonld">
+{
+  "id": "did:example:123#zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
+  "type": "Ed25519VerificationKey2020",
+  "controller": "did:example:123",
+  "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+}
+                  </pre>
+
       </section>
 
       <section id="publicKeyService" about="https://w3id.org/security#publicKeyService"


### PR DESCRIPTION
This PR partially addresses an issue in https://github.com/w3c/did-core/issues/707 by registering `publicKeyMultibase`, which is needed before registering `publicKeyMultibase` in https://github.com/w3c/did-spec-registries.