### PR TITLE
Fix typo in section 3.33 domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -2446,7 +2446,7 @@ revoked on May 5th 2012:
       typeof="rdf:Property">
         <h3>domain</h3>
         <p>
-          The challenge property is used to associate a domain with a proof, for use with a proofPurpose such as <code>authentication</code>.
+          The domain property is used to associate a domain with a proof, for use with a proofPurpose such as <code>authentication</code>.
                   </p>
                   <dl>
                     <dt>Status</dt>


### PR DESCRIPTION
Section 3.33 is concerned with the `domain` property, but the text refers to the `challenge` property, which appears to be incorrect.