### PR TITLE
Fix *Method definitions in namespace document

### DIFF
--- a/index.html
+++ b/index.html
@@ -1887,13 +1887,6 @@ to the identity <code>https://payswarm.example.com/i/bob</code>.
       typeof="rdf:Property">
         <h3>authentication (authenticationMethod)</h3>
 
-        <p class="note" title="Term differs from IRI suffix">
-For historical reasons, the term <code>authentication</code>
-is mapped to suffix <code>authenticationMethod</code> in the Security
-Vocabulary namespace, that is the following IRI:
-<code><a href="https://w3id.org/security#authenticationMethod">https://w3id.org/security#authenticationMethod</a></code>.
-        </p>
-
         <p>
           An authentication property is used to specify a URL that contains information about
           a verificationMethod used for authentication.
@@ -1939,13 +1932,6 @@ Vocabulary namespace, that is the following IRI:
       <section id="capabilityDelegationMethod" about="https://w3id.org/security#capabilityDelegationMethod"
       typeof="rdf:Property">
         <h3>capabilityDelegation (capabilityDelegationMethod)</h3>
-
-        <p class="note" title="Term differs from IRI suffix">
-For historical reasons, the term <code>capabilityDelegation</code>
-is mapped to suffix <code>capabilityDelegationMethod</code> in the Security
-Vocabulary namespace, that is the following IRI:
-<code><a href="https://w3id.org/security#capabilityDelegationMethod">https://w3id.org/security#capabilityDelegationMethod</a></code>.
-        </p>
 
         <p>
 A capabilityDelegation property is used to express that one or more
@@ -2010,13 +1996,6 @@ to the identity <code>did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5
       typeof="rdf:Property">
         <h3>capabilityInvocation (capabilityInvocationMethod)</h3>
 
-        <p class="note" title="Term differs from IRI suffix">
-For historical reasons, the term <code>capabilityInvocation</code>
-is mapped to suffix <code>capabilityInvocationMethod</code> in the Security
-Vocabulary namespace, that is the following IRI:
-<code><a href="https://w3id.org/security#capabilityInvocationMethod">https://w3id.org/security#capabilityInvocationMethod</a></code>.
-        </p>
-
         <p>
 A capabilityInvocation property is used to express that one or more
 verificationMethods are authorized to verify cryptographic proofs
@@ -2080,13 +2059,6 @@ to the identity <code>did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5
       <section id="keyAgreementMethod" about="https://w3id.org/security#keyAgreementMethod"
       typeof="rdf:Property">
         <h3>keyAgreement (keyAgreementMethod)</h3>
-
-        <p class="note" title="Term differs from IRI suffix">
-For historical reasons, the term <code>keyAgreement</code>
-is mapped to suffix <code>keyAgreementMethod</code> in the Security
-Vocabulary namespace, that is the following IRI:
-<code><a href="https://w3id.org/security#keyAgreementMethod">https://w3id.org/security#keyAgreementMethod</a></code>.
-        </p>
 
         <p>
           An keyAgreement property is used to specify a URL that contains information about

--- a/index.html
+++ b/index.html
@@ -1883,9 +1883,17 @@ to the identity <code>https://payswarm.example.com/i/bob</code>.
       </pre>
       </section>
 
-      <section id="authentication" about="https://w3id.org/security#authentication"
+      <section id="authenticationMethod" about="https://w3id.org/security#authenticationMethod"
       typeof="rdf:Property">
-        <h3>authentication</h3>
+        <h3>authentication (authenticationMethod)</h3>
+
+        <p class="note" title="Term differs from IRI suffix">
+For historical reasons, the term <code>authentication</code>
+is mapped to suffix <code>authenticationMethod</code> in the Security
+Vocabulary namespace, that is the following IRI:
+<code><a href="https://w3id.org/security#authenticationMethod">https://w3id.org/security#authenticationMethod</a></code>.
+        </p>
+
         <p>
           An authentication property is used to specify a URL that contains information about
           a verificationMethod used for authentication.
@@ -1928,9 +1936,17 @@ to the identity <code>https://payswarm.example.com/i/bob</code>.
       </pre>
       </section>
 
-      <section id="capabilityDelegation" about="https://w3id.org/security#capabilityDelegation"
+      <section id="capabilityDelegationMethod" about="https://w3id.org/security#capabilityDelegationMethod"
       typeof="rdf:Property">
-        <h3>capabilityDelegation</h3>
+        <h3>capabilityDelegation (capabilityDelegationMethod)</h3>
+
+        <p class="note" title="Term differs from IRI suffix">
+For historical reasons, the term <code>capabilityDelegation</code>
+is mapped to suffix <code>capabilityDelegationMethod</code> in the Security
+Vocabulary namespace, that is the following IRI:
+<code><a href="https://w3id.org/security#capabilityDelegationMethod">https://w3id.org/security#capabilityDelegationMethod</a></code>.
+        </p>
+
         <p>
 A capabilityDelegation property is used to express that one or more
 verificationMethods are authorized to verify cryptographic proofs
@@ -1990,9 +2006,17 @@ to the identity <code>did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5
         </pre>
       </section>
 
-      <section id="capabilityInvocation" about="https://w3id.org/security#capabilityInvocation"
+      <section id="capabilityInvocationMethod" about="https://w3id.org/security#capabilityInvocationMethod"
       typeof="rdf:Property">
-        <h3>capabilityInvocation</h3>
+        <h3>capabilityInvocation (capabilityInvocationMethod)</h3>
+
+        <p class="note" title="Term differs from IRI suffix">
+For historical reasons, the term <code>capabilityInvocation</code>
+is mapped to suffix <code>capabilityInvocationMethod</code> in the Security
+Vocabulary namespace, that is the following IRI:
+<code><a href="https://w3id.org/security#capabilityInvocationMethod">https://w3id.org/security#capabilityInvocationMethod</a></code>.
+        </p>
+
         <p>
 A capabilityInvocation property is used to express that one or more
 verificationMethods are authorized to verify cryptographic proofs
@@ -2053,9 +2077,17 @@ to the identity <code>did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5
         </pre>
       </section>
 
-      <section id="keyAgreement" about="https://w3id.org/security#keyAgreement"
+      <section id="keyAgreementMethod" about="https://w3id.org/security#keyAgreementMethod"
       typeof="rdf:Property">
-        <h3>keyAgreement</h3>
+        <h3>keyAgreement (keyAgreementMethod)</h3>
+
+        <p class="note" title="Term differs from IRI suffix">
+For historical reasons, the term <code>keyAgreement</code>
+is mapped to suffix <code>keyAgreementMethod</code> in the Security
+Vocabulary namespace, that is the following IRI:
+<code><a href="https://w3id.org/security#keyAgreementMethod">https://w3id.org/security#keyAgreementMethod</a></code>.
+        </p>
+
         <p>
           An keyAgreement property is used to specify a URL that contains information about
           a verificationMethod used for key agreement.


### PR DESCRIPTION
Address #91.

- Change ids and IRIs for the following properties in the namespace document (web page) to correspond with the IRIs used in the Security Vocab and DID Core JSON-LD contexts:
  - authentication → authenticationMethod
  - capabilityDelegation → capabilityDelegationMethod
  - capabilityInvocation → capabilityInvocationMethod
  - keyAgreement → keyAgreementMethod
- Use both the short names (e.g. authentication) and the long names (e.g. authenticationMethod) in the headings. The short name is for consistency with use in JSON-LD documents with the existing context files, as an established convention; and the long name is for consistency with `assertionMethod` (which does not have this discrepancy) and with the IRI itself (which uses the long name as the suffix following the namespace part).
- ~~Add notes about how/why it is this way.~~