### PR TITLE
Add EthereumEip712Signature2021

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,33 @@ until it is ratified as an official document via the World Wide Web Consortium.
         </pre>
       </section>
 
+      <section id="EthereumEip712Signature2021" about="https://w3id.org/security#EthereumEip712Signature2021"
+      typeof="rdfs:Class">
+        <h3>EthereumEip712Signature2021</h3>
+        <p>
+        This class represents a linked data signature suite. See <a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ethereumeip712signature2021">ethereumeip712signature2021</a>.
+        </p>
+        <dl>
+          <dt>Status</dt>
+          <dd property="vs:term_status">unstable</dd>
+          <dt>Expected properties</dt>
+          <dd>type, created, verificationMethod, proofPurpose, jws</dd>
+        </dl>
+        <pre class="example prettyprint language-jsonld">
+{
+  "type": "EthereumEip712Signature2021",
+  "created": "2019-12-11T03:50:55Z",
+  "proofPurpose": "assertionMethod",
+  "proofValue": "0xc565d38982e1a5004efb5ee390fba0a08bb5e72b3f3e91094c66bc395c324f785425d58d5c1a601372d9c16164e380c63e89f1e0ea95fdefdf7b2854c4f938e81b",
+  "verificationMethod": "did:example:aaaabbbb#issuerKey-1",
+  "eip712": {
+     "types": "https://example.com/schemas/v1",
+     "primaryType": "VerifiableCredential"
+  }
+}
+        </pre>
+      </section>
+
       <section id="EcdsaSecp256k1VerificationKey2019" about="https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"
       typeof="rdfs:Class">
         <h3>EcdsaSecp256k1VerificationKey2019</h3>


### PR DESCRIPTION
This adds a definition to the namespace document for the following term:
  <https://w3id.org/security#EthereumEip712Signature2021>
as specified in the following specification draft.

Specification draft: https://w3id.org/security/suites/eip712sig-2021
Source: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec
Issue about suite registration: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/issues/37
Cryptosuite registration request: https://github.com/w3c-ccg/ld-cryptosuite-registry/pull/39

The added section links to the suite's entry in Linked Data Cryptographic Suite Registry, like the other suites listed; that link will become valid when https://github.com/w3c-ccg/ld-cryptosuite-registry/pull/39 is merged, so this PR is in draft state until then.